### PR TITLE
fixes https://stackoverflow.com/questions/54719298/unfollow-user-not-woking-acts-as-follower-gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'activeadmin'
-gem 'acts_as_follower'
+gem 'acts_as_follower', github: 'tcocca/acts_as_follower', branch: 'master'
 
 
 group :development, :test do


### PR DESCRIPTION
The rubygems version 0.2.1 is old, from 2013. The bug you were experiencing has been fixed but is only on Github, so you need to tell Bundler to get it from the github repo instead of it defaultly going to rubygems.